### PR TITLE
Pre-compute squared x and y

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,13 +27,17 @@ fn mandelbrot(px: usize, py: usize) -> u32 {
     let y0: f64 = map(py as f64, 0f64, HEIGHT as f64, -1f64, 1f64);
     let mut x = 0f64;
     let mut y = 0f64;
+    let mut xsqrt = 0;
+    let mut ysqrt = 0;
     let mut iter: f64 = 0f64;
     let max_iter: f64 = 64f64;
-    while x * x + y * y < 4f64 && iter < max_iter {
-        let xt: f64 = x * x - y * y + x0;
+    while xsqrt + ysqrt < 4f64 && iter < max_iter {
+        let xt: f64 = xsqrt - ysqrt + x0;
         y = 2f64 * x * y + y0;
         x = xt;
         iter += 1f64;
+        xsqrt = x * x;
+        ysqrt = y * y;
     }
 
     if iter < max_iter {


### PR DESCRIPTION
This should shave off two pow-operations per loop iteration,
and a whole lot of them during the rendering process.